### PR TITLE
Continuous Integration workflow with GitHub Actions and Codecov

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.6'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+        arch:
+          - x64
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Set up Julia
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+
+      - name: Load cache
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - name: Build package
+        uses: julia-actions/julia-buildpkg@v1
+
+      - name: Run tests
+        uses: julia-actions/julia-runtest@v1
+
+      - name: Process code coverage
+        uses: julia-actions/julia-processcoverage@v1
+
+      - name: Run codecov action
+        uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Hello, hope you're doing well!

I added a GitHub Actions workflow that builds the package and runs the unit tests (which we don't have yet) upon pull request to master branch. The goal is to make it straightforward to review changes when other contributors make new pull requests, which I hope will be the case in the near future.

Also, the last part of the workflow submits the results of the tests to [Codecov](https://app.codecov.io/gh/+), which generates a nice report on code coverage. Since that's a third-party software, only the owner of the repository can grant access to the repo. If you think that's a good idea, you can just enable Codecov for this repo from your Codecov account (in the link above).

Cheers!