### PR TITLE
Reexport DataFrames and DataStructures objects for se contruction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,11 @@ version = "0.1.0"
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 DataFrames = "1"
-DataStructures = "0.18" 
+DataStructures = "0.18"
 julia = "1"
 
 [extras]

--- a/src/SummarizedExperiments.jl
+++ b/src/SummarizedExperiments.jl
@@ -7,4 +7,9 @@ include("setters.jl")
 include("combine.jl")
 include("miscellaneous.jl")
 include("example.jl")
+
+using Reexport
+@reexport using DataStructures: OrderedDict
+@reexport using DataFrames: DataFrame
+
 end

--- a/src/class.jl
+++ b/src/class.jl
@@ -2,16 +2,16 @@
 # import DataFrames
 # import DataStructures
 
-function check_dataframe_has_name(x::DataFrames.DataFrame)
+function check_dataframe_has_name(x::DataFrame)
     return size(x)[2] >= 1 && names(x)[1] == "name"
 end
 
-function check_dataframe_firstcol(x::DataFrames.DataFrame)
+function check_dataframe_firstcol(x::DataFrame)
     first = x[!,1]
     return isa(first, AbstractVector{<:AbstractString}) || isa(first, Vector{Nothing})
 end
 
-function check_dataframe_in_constructor(x::DataFrames.DataFrame, message::String)
+function check_dataframe_in_constructor(x::DataFrame, message::String)
     if !check_dataframe_has_name(x)
         throw(ArgumentError("first column of '" * message * "' should be 'name'"))
     end
@@ -43,9 +43,9 @@ If no names are present, the `"name"` column must contain `nothing`s.
 Each instance may also contain arbitrary metadata not associated with the rows or columns.
 """
 mutable struct SummarizedExperiment
-    assays::DataStructures.OrderedDict{String,AbstractArray}
-    rowdata::DataFrames.DataFrame
-    coldata::DataFrames.DataFrame
+    assays::OrderedDict{String,AbstractArray}
+    rowdata::DataFrame
+    coldata::DataFrame
     metadata::Dict{String,Any}
 
     @doc """
@@ -68,9 +68,9 @@ mutable struct SummarizedExperiment
     ```
     """
     function SummarizedExperiment()
-        dummy = DataFrames.DataFrame(name = String[])
+        dummy = DataFrame(name = String[])
         new(
-           DataStructures.OrderedDict{String,AbstractArray}(), 
+           OrderedDict{String,AbstractArray}(), 
            dummy,
            deepcopy(dummy),
            Dict{String,Any}()
@@ -93,7 +93,7 @@ mutable struct SummarizedExperiment
     ```jldoctest
     julia> using SummarizedExperiments
 
-    julia> using DataFrames, DataStructures
+    julia> # using DataFrames, DataStructures
 
     julia> assays = OrderedDict{String, AbstractArray}(
               "foobar" => [[1,2] [3,4] [5,6]], 
@@ -109,7 +109,7 @@ mutable struct SummarizedExperiment
       metadata(0):
     ```
     """
-    function SummarizedExperiment(assays::DataStructures.OrderedDict{String, AbstractArray})
+    function SummarizedExperiment(assays::OrderedDict{String, AbstractArray})
         if length(assays) < 1
             throw(ErrorException("expected at least one array in 'assays' if 'rowdata' or 'coldata' are not supplied"))
         end
@@ -127,8 +127,8 @@ mutable struct SummarizedExperiment
             end
         end
 
-        rowdata = DataFrames.DataFrame(name = Vector{Nothing}(undef, refdims[1]))
-        coldata = DataFrames.DataFrame(name = Vector{Nothing}(undef, refdims[2]))
+        rowdata = DataFrame(name = Vector{Nothing}(undef, refdims[1]))
+        coldata = DataFrame(name = Vector{Nothing}(undef, refdims[2]))
         new(assays, rowdata, coldata, Dict{String,Any}())
     end
 
@@ -151,7 +151,7 @@ mutable struct SummarizedExperiment
     ```jldoctest
     julia> using SummarizedExperiments
 
-    julia> using DataFrames, DataStructures
+    julia> # using DataFrames, DataStructures
 
     julia> assays = OrderedDict{String, AbstractArray}(
               "foobar" => [[1,2] [3,4] [5,6]], 
@@ -176,9 +176,9 @@ mutable struct SummarizedExperiment
     ```
     """
     function SummarizedExperiment(
-            assays::DataStructures.OrderedDict{String, AbstractArray},
-            rowdata::DataFrames.DataFrame,
-            coldata::DataFrames.DataFrame,
+            assays::OrderedDict{String, AbstractArray},
+            rowdata::DataFrame,
+            coldata::DataFrame,
             metadata::Dict{String,Any} = Dict{String,Any}()
         )
 

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -1,7 +1,7 @@
 # import DataFrames
 # import DataStructures
 
-function collapse_data(x::Vector{DataFrames.DataFrame})
+function collapse_data(x::Vector{DataFrame})
     base = copy(x[1])
     refnames = Set(names(base))
 
@@ -79,7 +79,7 @@ function Base.vcat(A::Vararg{SummarizedExperiment})
     collected_rowdata = [rowdata(A[1])];
     collected_coldata = [coldata(A[1])];
     collected_metadata = [metadata(A[1])];
-    collected_assays = DataStructures.OrderedDict{String,Vector{AbstractArray}}();
+    collected_assays = OrderedDict{String,Vector{AbstractArray}}();
     for (key, val) in assays(A[1])
         collected_assays[key] = AbstractArray[val]
     end
@@ -103,7 +103,7 @@ function Base.vcat(A::Vararg{SummarizedExperiment})
     end
 
     full_rowdata = vcat(collected_rowdata...)
-    full_assays = DataStructures.OrderedDict{String,AbstractArray}()
+    full_assays = OrderedDict{String,AbstractArray}()
     for (key, val) in collected_assays
         full_assays[key] = vcat(val...)
     end
@@ -157,7 +157,7 @@ function Base.hcat(A::Vararg{SummarizedExperiment})
     collected_rowdata = [rowdata(A[1])];
     collected_coldata = [coldata(A[1])];
     collected_metadata = [metadata(A[1])];
-    collected_assays = DataStructures.OrderedDict{String,Vector{AbstractArray}}();
+    collected_assays = OrderedDict{String,Vector{AbstractArray}}();
     for (key, val) in assays(A[1])
         collected_assays[key] = AbstractArray[val]
     end
@@ -181,7 +181,7 @@ function Base.hcat(A::Vararg{SummarizedExperiment})
     end
 
     full_coldata = vcat(collected_coldata...)
-    full_assays = DataStructures.OrderedDict{String,AbstractArray}()
+    full_assays = OrderedDict{String,AbstractArray}()
     for (key, val) in collected_assays
         full_assays[key] = hcat(val...)
     end

--- a/src/example.jl
+++ b/src/example.jl
@@ -38,21 +38,21 @@ function exampleobject(nrow::Int64, ncol::Int64)
         third_assay[i] = -rand()
     end
 
-    assays = DataStructures.OrderedDict{String, AbstractArray}(
+    assays = OrderedDict{String, AbstractArray}(
         "foo" => first_assay, 
         "bar" => second_assay, 
         "whee" => third_assay
     )
 
     tchoices = ["normal", "drug1", "drug2"]
-    coldata = DataFrames.DataFrame(
+    coldata = DataFrame(
         "name" => [ "Patient" * string(i) for i in 1:ncol ],
         "Treatment" => [ tchoices[Int(floor(rand() * length(tchoices) + 1))] for i in 1:ncol ],
         "Response" => [ rand() for i in 1:ncol ]
     )
 
     gchoices = ["Protein-coding", "Pseudogene"]
-    rowdata = DataFrames.DataFrame(
+    rowdata = DataFrame(
         "name" => [ "Gene" * string(i) for i in 1:nrow ],
         "Type" => [ gchoices[Int(floor(rand() * length(gchoices) + 1))] for i in 1:nrow ]
     )

--- a/src/getters.jl
+++ b/src/getters.jl
@@ -21,7 +21,7 @@ function Base.size(x::SummarizedExperiment)
     return (size(x.rowdata)[1], size(x.coldata)[1])
 end
 
-function check_dataframe_in_getter(value::DataFrames.DataFrame, expected::Int, message::String)
+function check_dataframe_in_getter(value::DataFrame, expected::Int, message::String)
     if expected != size(value)[1]
         @warn "'" * message * "(x)' has a different number of rows than 'x'"
         return

--- a/src/miscellaneous.jl
+++ b/src/miscellaneous.jl
@@ -5,7 +5,7 @@ Return a copy of `x`, where all components are identically-same as those in `x`.
 
 # Examples
 ```jldoctest
-julia> using SummarizedExperiments, DataFrames
+julia> using SummarizedExperiments # , DataFrames
 
 julia> x = exampleobject(20, 10);
 
@@ -47,7 +47,7 @@ Return a deep copy of `x` and all of its components.
 
 # Examples
 ```jldoctest
-julia> using SummarizedExperiments, DataFrames
+julia> using SummarizedExperiments # , DataFrames
 
 julia> x = exampleobject(20, 10);
 

--- a/src/setters.jl
+++ b/src/setters.jl
@@ -2,7 +2,7 @@
 # import DataFrames
 # import DataStructures
 
-function check_dataframe_in_setter(value::DataFrames.DataFrame, expected::Int, message::String)
+function check_dataframe_in_setter(value::DataFrame, expected::Int, message::String)
     if size(value)[1] != expected
         throw(DimensionMismatch("'value' and '" * message *"(x)' should have the same number of rows"))
     end
@@ -34,7 +34,7 @@ julia> using SummarizedExperiments
 
 julia> x = exampleobject(20, 10);
 
-julia> using DataFrames
+julia> # using DataFrames
 
 julia> replacement = copy(rowdata(x));
 
@@ -49,9 +49,9 @@ julia> names(rowdata(x))
  "foobar"
 ```
 """    
-function setrowdata!(x::SummarizedExperiment, value::Union{DataFrames.DataFrame,Nothing})
+function setrowdata!(x::SummarizedExperiment, value::Union{DataFrame,Nothing})
     if isa(value, Nothing)
-        x.rowdata = DataFrames.DataFrame(name = Vector{Nothing}(undef, size(x)[1]))
+        x.rowdata = DataFrame(name = Vector{Nothing}(undef, size(x)[1]))
     else
         check_dataframe_in_setter(value, size(x)[1], "rowdata")
         x.rowdata = value
@@ -77,7 +77,7 @@ julia> using SummarizedExperiments
 
 julia> x = exampleobject(20, 10);
 
-julia> using DataFrames
+julia> # using DataFrames
 
 julia> replacement = copy(coldata(x));
 
@@ -93,9 +93,9 @@ julia> names(coldata(x))
  "foobar"
 ```
 """
-function setcoldata!(x::SummarizedExperiment, value::Union{DataFrames.DataFrame,Nothing})
+function setcoldata!(x::SummarizedExperiment, value::Union{DataFrame,Nothing})
     if isa(value, Nothing)
-        x.coldata = DataFrames.DataFrame(name = Vector{Nothing}(undef, size(x)[2]))
+        x.coldata = DataFrame(name = Vector{Nothing}(undef, size(x)[2]))
     else
         check_dataframe_in_setter(value, size(x)[2], "coldata")
         x.coldata = value
@@ -195,7 +195,7 @@ julia> length(assays(x))
 2
 ```
 """
-function setassays!(x::SummarizedExperiment, value::DataStructures.OrderedDict{String,AbstractArray})
+function setassays!(x::SummarizedExperiment, value::OrderedDict{String,AbstractArray})
     xdim = size(x)
     for (name, val) in value
         dim = size(val)

--- a/src/subset.jl
+++ b/src/subset.jl
@@ -68,7 +68,7 @@ function Base.getindex(x::SummarizedExperiment, i, j)
     new_rowdata = x.rowdata[index_rows,:]
     new_coldata = x.coldata[index_cols,:]
 
-    new_assays = DataStructures.OrderedDict{String,AbstractArray}();
+    new_assays = OrderedDict{String,AbstractArray}();
     for (key, val) in x.assays
         subdex = Array{Any,1}(undef, length(size(val)))
         fill!(subdex, :)

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -1,0 +1,8 @@
+mat1 = ones(10, 10)
+mat2 = zeros(20, 5)
+assays = OrderedDict{String, AbstractArray}("matrix1" => mat1,
+                                            "matrix2" => mat2)
+
+function make_assays(kwargs...)
+
+    


### PR DESCRIPTION
With this changes the objects DataFrame and OrderedDict will be part of SummarizedExperiments.jl and explicitly `using` those deps won't be necessary.